### PR TITLE
Update ModMenu API implementation

### DIFF
--- a/src/main/java/grondag/tdnf/Configurator.java
+++ b/src/main/java/grondag/tdnf/Configurator.java
@@ -19,7 +19,6 @@ package grondag.tdnf;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -73,9 +72,6 @@ public class Configurator {
     public static int maxBreaksPerTick = DEFAULTS.maxBreaksPerTick;
     public static int breakCooldownTicks = DEFAULTS.breakCooldownTicks;
     public static int maxSearchPosPerTick = DEFAULTS.maxSearchPosPerTick;
-    
-    /** use to stash parent screen during display */
-    private static Screen screenIn;
     
     private static File configFile;
     
@@ -134,9 +130,9 @@ public class Configurator {
     }
     
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    private static Screen display() {
+    static Screen getScreen(Screen parent) {
         
-        ConfigScreenBuilder builder = ConfigScreenBuilder.create(screenIn, "config.tdnf.title", Configurator::saveUserInput);
+        ConfigScreenBuilder builder = ConfigScreenBuilder.create(parent, "config.tdnf.title", Configurator::saveUserInput);
         
         // FEATURES
         ConfigScreenBuilder.CategoryBuilder features = builder.addCategory("config.tdnf.category.features");
@@ -170,16 +166,6 @@ public class Configurator {
         builder.setDoesConfirmSave(false);
         
         return builder.build();
-    }
-    
-    public static Optional<Supplier<Screen>> getConfigScreen(Screen screen) {
-        screenIn = screen;
-        return Optional.of(Configurator::display);
-    }
-    
-    public static Screen getRawConfigScreen(Screen screen) {
-        screenIn = screen;
-        return display();
     }
     
     private static void saveUserInput(SavedConfig config) {

--- a/src/main/java/grondag/tdnf/ModMenuHelper.java
+++ b/src/main/java/grondag/tdnf/ModMenuHelper.java
@@ -16,8 +16,7 @@
 
 package grondag.tdnf;
 
-import java.util.Optional;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import io.github.prospector.modmenu.api.ModMenuApi;
 import net.fabricmc.api.EnvType;
@@ -27,8 +26,8 @@ import net.minecraft.client.gui.screen.Screen;
 @Environment(EnvType.CLIENT)
 public class ModMenuHelper implements ModMenuApi {
     @Override
-    public Optional<Supplier<Screen>> getConfigScreen(Screen screen) {
-        return Configurator.getConfigScreen(screen);
+    public Function<Screen, ? extends Screen> getConfigScreenFactory() {
+        return Configurator::getScreen;
     }
     
     @Override


### PR DESCRIPTION
Removes the redundant parent caching pattern, and migrates to the proper API method that takes a `Function<Screen, ? extends Screen>` factory.